### PR TITLE
Update Pillow Version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ beautifulsoup4==4.8.2
 pathlib~=1.0.1
 premailer~=3.7.0
 cssutils~=1.0.2
-Pillow~=7.0.0
+Pillow~=8.0.0
 svglib~=1.0.1
 reportlab~=3.5.34
 config~=0.5.0.post0


### PR DESCRIPTION
Pillow 7.0.0 doesn't support Python 3.9, Pillow 8.0.0 does and appears to work fine for me